### PR TITLE
Adding ActionScript Date properties to the missing.js file

### DIFF
--- a/js/src/main/config/externc-config.xml
+++ b/js/src/main/config/externc-config.xml
@@ -174,4 +174,10 @@
     <exclude><class>SVGLocatable</class><name>farthestViewportElement</name></exclude>
     <exclude><class>SVGLocatable</class><name>nearestViewportElement</name></exclude>
 
+    <!-- read-only properties where we only emit a 'get' accessor method -->
+    <field-readonly>
+        <class>Date</class>
+        <name>timezoneOffset</name>
+    </field-readonly>
+    
 </royale-config>

--- a/js/src/main/javascript/missing.js
+++ b/js/src/main/javascript/missing.js
@@ -250,3 +250,96 @@ uint.MAX_VALUE;
  * @const
  */
 uint.MIN_VALUE;
+
+// additions to the Date prototype to allow AS code to use these properties
+
+/**
+ * @type {number}
+ */
+Date.prototype.date;
+
+/**
+ * @type {number}
+ */
+Date.prototype.dateUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.day;
+
+/**
+ * @type {number}
+ */
+Date.prototype.dayUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.fullYear;
+
+/**
+ * @type {number}
+ */
+Date.prototype.fullYearUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.hours;
+
+/**
+ * @type {number}
+ */
+Date.prototype.hoursUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.milliseconds;
+
+/**
+ * @type {number}
+ */
+Date.prototype.millisecondsUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.minutes;
+
+/**
+ * @type {number}
+ */
+Date.prototype.minutesUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.month;
+
+/**
+ * @type {number}
+ */
+Date.prototype.monthUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.seconds;
+
+/**
+ * @type {number}
+ */
+Date.prototype.secondsUTC;
+
+/**
+ * @type {number}
+ */
+Date.prototype.time;
+
+/**
+ * @type {number}
+ */
+Date.prototype.timezoneOffset;
+


### PR DESCRIPTION
Prevents the royale-compiler from reporting an undefined property error when someone uses ActionScript along the lines of "(new Date()).fullYear".
